### PR TITLE
Alter tocalivros.com.br for tocalivros.com

### DIFF
--- a/2016/06/22/audiobooks.html
+++ b/2016/06/22/audiobooks.html
@@ -130,7 +130,7 @@ acelerar o audio, o que para mim o torna quase inutilizável. O serviço não te
 uma biblioteca tão vasta como a do Audible, mas possui vários livros legais. O
 valor é quase metade do valor do Audible e pode ser uma alternativa assim que
 implementarem a aceleração de audio.</li>
-<li><a href="http://tocalivros.com.br">Tocalivros</a> &ndash; É a alternativa brasileira de
+<li><a href="http://tocalivros.com">Tocalivros</a> &ndash; É a alternativa brasileira de
 distribuição e criação de audiobooks. O player deles melhorou muito nos
 últimos meses e está quase chegando lá. Infelizmente a quantidade de títulos
 bons ainda é bem baixa e nem se compara com serviços gringos ainda.</li>


### PR DESCRIPTION
Aeeeee Pothix, estava escutando o podcast do Dev na estrada, e fui ver o post do audiobook e acabei vendo que o site do tocalivros não existe por conta do 'br' no final, ai alterei para tocalivros.com, para poder acessar.